### PR TITLE
Support web workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ const { ComplexZmanimCalendar, getZmanimJson } = require("kosher-zmanim");
 
 For UMD, a global `KosherZmanim` object is exposed.
 
+**Web Worker**
+
+In your worker, assuming the following project structure
+```
+- node_modules/
+-- kosher-zmanim/
+- worker.js
+```
+Worker code:
+```javascript
+importScripts('node_modules/kosher-zmanim/lib-worker/kosher-zmanim.min.js')
+const { ComplexZmanimCalendar, getZmanimJson } = KosherZmanim
+```
+
 #### Library Usage:
 The KosherJava library has been ported to JS, following the original API as close as possible.
 The classes are exposed as named exports. You can instantiate or extend those classes as necessary, the same way you would in Java.

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
   "scripts": {
     "clean": "rimraf ./dist/*",
     "build": "npm run clean && npm run build:all && npm run webpack",
-    "build:all": "npm run build:cjs && npm run build:es6 && npm run build:types",
+    "build:all": "npm run build:cjs && npm run build:es6 && npm run build:types && npm run build:worker",
     "build:cjs": "tsc -p ./src/",
     "build:es6": "tsc -p ./src/tsconfig-es6.json",
     "build:types": "tsc -p ./src/tsconfig-types.json",
+    "build:worker": "webpack --config worker.webpack.config.js",
     "lint": "eslint --ext .ts src tests",
     "test": "jest",
     "prepublishOnly": "npm run build",

--- a/worker.webpack.config.js
+++ b/worker.webpack.config.js
@@ -1,0 +1,54 @@
+const path = require("path");
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+
+module.exports = {
+  mode: "production",
+  devtool: 'source-map',
+  context: __dirname,
+  target: "webworker",
+  entry: {
+    "kosher-zmanim": "./src/kosher-zmanim.ts",
+    "kosher-zmanim.min": "./src/kosher-zmanim.ts",
+  },
+  output: {
+    filename: "[name].js",
+    path: path.resolve(__dirname, "./dist/lib-worker"),
+    library: "KosherZmanim",
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: [
+          {
+            loader: "ts-loader",
+            options: {
+              transpileOnly: true,
+              logInfoToStdOut: true,
+              compilerOptions: {
+                target: "es5",
+                module: "es6",
+              },
+              configFile: "src/tsconfig.json",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  resolve: {
+    extensions: [".ts", ".js"],
+  },
+  optimization: {
+    minimizer: [new UglifyJsPlugin({
+      sourceMap: true,
+      include: /\.min\.js$/,
+      uglifyOptions: {
+        mangle: {
+          keep_fnames: true,
+        },
+      },
+    })],
+  },
+};
+


### PR DESCRIPTION
Sometimes, people want to use the code in web-workers.

Specifically, one of my relatives wanted to use this library in a Wix Corvid application. They need to use a target compiled for web-workers in order for it to work. 
This PR creates a worker target.

After the build, it would probably be good to add a link to unpkg with the compiled worker target, to make it easier