### PR TITLE
fix: implement correct clone for JewishCalendar

### DIFF
--- a/src/hebrewcalendar/HebrewDateFormatter.ts
+++ b/src/hebrewcalendar/HebrewDateFormatter.ts
@@ -487,7 +487,7 @@ export class HebrewDateFormatter {
 
     // This method is only about formatting, so we shouldn't make any changes to the params passed in...
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const _jewishCalendar = jewishCalendar.clone() as JewishCalendar;
+    const _jewishCalendar = jewishCalendar.clone();
     _jewishCalendar.setJewishMonth(month);
     formattedRoshChodesh = this.hebrewFormat ? HebrewDateFormatter.hebrewHolidays[JewishCalendar.ROSH_CHODESH]
       : this.transliteratedHolidays[JewishCalendar.ROSH_CHODESH];

--- a/src/hebrewcalendar/JewishCalendar.ts
+++ b/src/hebrewcalendar/JewishCalendar.ts
@@ -594,7 +594,7 @@ export class JewishCalendar extends JewishDate {
    * @return the upcoming <em>parsha</em>.
    */
   public getUpcomingParsha(): Parsha {
-    const clone: JewishCalendar = this.clone() as JewishCalendar;
+    const clone: JewishCalendar = this.clone();
     const daysToShabbos: number = (Calendar.SATURDAY - this.getDayOfWeek() + 7) % 7;
     if (this.getDayOfWeek() !== Calendar.SATURDAY) {
       clone.forward(Calendar.DATE, daysToShabbos);
@@ -1270,8 +1270,8 @@ export class JewishCalendar extends JewishDate {
    */
   public isPurim(): boolean {
     return this.isMukafChoma
-        ? this.getYomTovIndex() === JewishCalendar.SHUSHAN_PURIM
-        : this.getYomTovIndex() === JewishCalendar.PURIM;
+      ? this.getYomTovIndex() === JewishCalendar.SHUSHAN_PURIM
+      : this.getYomTovIndex() === JewishCalendar.PURIM;
   }
 
   /**
@@ -1501,6 +1501,21 @@ export class JewishCalendar extends JewishDate {
   public isIsruChag(): boolean {
     const holidayIndex: number = this.getYomTovIndex();
     return holidayIndex === JewishCalendar.ISRU_CHAG;
+  }
+
+  /**
+   * A method that creates a <a href="https://en.wikipedia.org/wiki/Object_copy#Deep_copy">deep copy</a> of the object.
+   *
+   * @see Object#clone()
+   */
+  public clone(): JewishCalendar {
+    const clone: JewishCalendar = new JewishCalendar(this.getJewishYear(), this.getJewishMonth(), this.getJewishDayOfMonth());
+    clone.setMoladHours(this.getMoladHours());
+    clone.setMoladMinutes(this.getMoladMinutes());
+    clone.setMoladChalakim(this.getMoladChalakim());
+    clone.setInIsrael(this.getInIsrael());
+    clone.setIsMukafChoma(this.getIsMukafChoma());
+    return clone;
   }
 
   /**


### PR DESCRIPTION
The `getUpcomingParsha` function called clone, which created a new `JewishDate` object instead of a `JewishCalendar` object. The former lacks the necessary `getParsha` function causing an error when called:

`TypeError: clone.getParsha is not a function. (In 'clone.getParsha()', 'clone.getParsha' is undefined)`